### PR TITLE
fix: render item categories as array

### DIFF
--- a/components/cart/cart-item.tsx
+++ b/components/cart/cart-item.tsx
@@ -45,7 +45,9 @@ export function CartItem({ item, onRemove }: CartItemProps) {
 
       <div className="flex-1 min-w-0 py-1">
         <h4 className="font-medium leading-tight">{name}</h4>
-        <p className="text-sm text-muted-foreground mt-1">{item.category}</p>
+        {item.category && item.category.length > 0 && (
+          <p className="text-sm text-muted-foreground mt-1">{item.category.join(', ')}</p>
+        )}
         {item.deposit > 0 && (
           <p className="text-sm font-medium mt-1">{item.deposit}&euro;</p>
         )}

--- a/components/item/item-detail.tsx
+++ b/components/item/item-detail.tsx
@@ -140,8 +140,8 @@ export function ItemDetail({ item }: ItemDetailProps) {
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold">{name}</h1>
-          {item.category && (
-            <p className="text-lg text-muted-foreground mt-1">{item.category}</p>
+          {item.category && item.category.length > 0 && (
+            <p className="text-lg text-muted-foreground mt-1">{item.category.join(', ')}</p>
           )}
         </div>
 

--- a/lib/api/items.ts
+++ b/lib/api/items.ts
@@ -2,6 +2,21 @@ import { fetchApi } from "./client";
 import { Item, ItemsResponse } from "@/lib/types/item";
 import { config } from "@/lib/config";
 
+function normalizeItem(item: Item): Item {
+  let category = (item as unknown as { category: unknown }).category;
+  if (typeof category === 'string') {
+    try {
+      const parsed = JSON.parse(category);
+      category = Array.isArray(parsed) ? parsed : [category];
+    } catch {
+      // Not JSON — treat as single category or empty if blank
+      category = category ? [category] : [];
+    }
+  }
+  if (!Array.isArray(category)) category = [];
+  return { ...item, category: category as string[] };
+}
+
 export async function getItems(
   page: number = 1,
   perPage: number = 30,
@@ -31,13 +46,15 @@ export async function getItems(
     perPage: perPage.toString(),
   });
 
-  return fetchApi<ItemsResponse>(
+  const raw = await fetchApi<ItemsResponse>(
     `/api/collections/item_public/records?${params.toString()}`
   );
+  return { ...raw, items: raw.items.map(normalizeItem) };
 }
 
 export async function getItem(id: string): Promise<Item> {
-  return fetchApi<Item>(`/api/collections/item_public/records/${id}`);
+  const raw = await fetchApi<Item>(`/api/collections/item_public/records/${id}`);
+  return normalizeItem(raw);
 }
 
 export async function getItemByIid(iid: number): Promise<Item | null> {
@@ -50,5 +67,5 @@ export async function getItemByIid(iid: number): Promise<Item | null> {
     `/api/collections/item_public/records?${params.toString()}`
   );
 
-  return response.items.length > 0 ? response.items[0] : null;
+  return response.items.length > 0 ? normalizeItem(response.items[0]) : null;
 }

--- a/lib/types/item.ts
+++ b/lib/types/item.ts
@@ -33,7 +33,7 @@ export interface Item {
   status: ItemStatus;
   deposit: number;
   synonyms: string;
-  category: string;
+  category: string[];
   brand: string;
   model: string;
   packaging: string;


### PR DESCRIPTION
## Root cause

In the backend (`leihbackend`), `item.category` is a multi-select field (`maxSelect: 7`) that stores its values as a JSON array in SQLite. The `item_public` view projects that column as type `text`, so the resomaker receives the raw serialized string — e.g. `'["Garten","Heimwerken"]'` — instead of a parsed array. The resomaker typed the field as `string` and rendered it directly with `{item.category}`, so the literal JSON appeared in the UI.

## Changes

- **`lib/types/item.ts`** — changed `category: string` → `category: string[]`
- **`lib/api/items.ts`** — added a `normalizeItem()` helper that detects when the field arrives as a raw JSON string and parses it into a proper `string[]`. Applied in `getItems`, `getItem`, and `getItemByIid`.
- **`components/item/item-detail.tsx`** — renders `item.category.join(', ')` (guarded on non-empty array)
- **`components/cart/cart-item.tsx`** — same treatment

The `category~"…"` search filter in `getItems` is left untouched — PocketBase's `~` operator does substring matching on the raw stored value, so it continues to work correctly.

## Follow-up worth considering

This is a **client-side fix**. A cleaner long-term fix would be on the backend side: change the `item_public` view so the `category` column is returned as a proper JSON array (or have PocketBase expose it as a native multi-select field rather than a text projection). That would eliminate the need for the defensive parsing in `normalizeItem`.

Fixes #6